### PR TITLE
Use relative path to llvm link to not depend on version

### DIFF
--- a/profiles/clang-6.0-macos-x86_64
+++ b/profiles/clang-6.0-macos-x86_64
@@ -13,5 +13,5 @@ build_type=Release
 [options]
 [env]
 # Brew install llvm@6
-CC=/usr/local/Cellar/llvm\@6/6.0.1_1/bin/clang
-CXX=/usr/local/Cellar/llvm\@6/6.0.1_1/bin/clang++
+CC=/usr/local/opt/llvm\@6/bin/clang
+CXX=/usr/local/opt/llvm\@6/bin/clang++


### PR DESCRIPTION
Use relative path to llvm@6 in macos profile

Signed-off-by: Magnus Skjegstad <magnus@skjegstad.com>