### PR TITLE
Setting cppstd is deprecated to compiler.cppstd

### DIFF
--- a/profiles/clang-6.0-macos-x86_64
+++ b/profiles/clang-6.0-macos-x86_64
@@ -8,7 +8,7 @@ arch_build=x86_64
 compiler=clang
 compiler.version=6.0
 compiler.libcxx=libc++
-cppstd=17
+compiler.cppstd=17
 build_type=Release
 [options]
 [env]


### PR DESCRIPTION
In Conan version `1.15.0` the setting `cppstd` has been deprecated to `compiler.cppstd`.

```
UserWarning: Setting 'cppstd' is deprecated in favor of 'compiler.cppstd'
  warnings.warn("Setting 'cppstd' is deprecated in favor of 'compiler.cppstd'")
```